### PR TITLE
Resolved profile_interest Not Being Populated

### DIFF
--- a/src/main/webapp/WEB-INF/tiles/profile.jsp
+++ b/src/main/webapp/WEB-INF/tiles/profile.jsp
@@ -21,7 +21,7 @@
 					</c:when>
 					<c:otherwise>
 						<c:forEach var="interest" items="${profile.interests}">
-							<li>${interest}</li>
+							<li>${interest.name}</li>
 						</c:forEach>
 					</c:otherwise>
 				</c:choose>


### PR DESCRIPTION
For whatever reason, the interest_id field wasn't being populated by Hibernate. Dropping the profile_interests and interests tables resolved the issue.

Also fixed issue where the object reference was being printed instead of the interest name.